### PR TITLE
refactor: call dotnet/checkout-build job macro from dotnet/checkout-build-pack job

### DIFF
--- a/jobs/dotnet/checkout-build-pack/action.yml
+++ b/jobs/dotnet/checkout-build-pack/action.yml
@@ -147,8 +147,13 @@ outputs:
 runs:
   using: composite
   steps:
-  - uses: actions/checkout@v4
+  - uses: kagekirin/gha-py-toolbox/jobs/dotnet/checkout-build@main
     with:
+      path: ${{ inputs.path }}
+      projects: ${{ inputs.projects }}
+      configurations: ${{ inputs.configurations }}
+      frameworks: ${{ inputs.frameworks }}
+
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
       token: ${{ inputs.token }}
@@ -157,7 +162,6 @@ runs:
       ssh-strict: ${{ inputs.ssh-strict }}
       ssh-user: ${{ inputs.ssh-user }}
       persist-credentials: ${{ inputs.persist-credentials }}
-      path: ${{ inputs.path }}
       clean: ${{ inputs.clean }}
       filter: ${{ inputs.filter }}
       sparse-checkout: ${{ inputs.sparse-checkout }}
@@ -169,14 +173,6 @@ runs:
       submodules: ${{ inputs.submodules }}
       set-safe-directory: ${{ inputs.set-safe-directory }}
       github-server-url: ${{ inputs.github-server-url }}
-
-  - id: build
-    uses: kagekirin/gha-py-toolbox/actions/dotnet/build@main
-    with:
-      path: ${{ inputs.path }}
-      projects: ${{ inputs.projects }}
-      configurations: ${{ inputs.configurations }}
-      frameworks: ${{ inputs.frameworks }}
 
   - id: pack
     uses: kagekirin/gha-py-toolbox/actions/dotnet/pack@main


### PR DESCRIPTION
reason: reduce duplicate code
