### PR TITLE
refactor: call git/get-highest-semver-tag from dotnet/bump-version-tag macro

### DIFF
--- a/macros/dotnet/bump-version-tag/action.yml
+++ b/macros/dotnet/bump-version-tag/action.yml
@@ -37,7 +37,7 @@ outputs:
 runs:
   using: composite
   steps:
-  - id: latest-tag
+  - id: highest-tag
     name: Get latest version tag
     uses: kagekirin/gha-py-toolbox/actions/git/get-highest-semver-tag@main
     with:
@@ -47,7 +47,7 @@ runs:
     name: Compute next version
     uses: kagekirin/gha-py-toolbox/actions/semver/bump-version@main
     with:
-      version: ${{ steps.latest-tag.outputs.version }}
+      version: ${{ steps.highest-tag.outputs.version }}
       bump_patch: true
 
   - id: update-projects

--- a/macros/dotnet/bump-version-tag/action.yml
+++ b/macros/dotnet/bump-version-tag/action.yml
@@ -39,7 +39,7 @@ runs:
   steps:
   - id: latest-tag
     name: Get latest version tag
-    uses: kagekirin/gha-py-toolbox/actions/git/get-latest-version-tag@main
+    uses: kagekirin/gha-py-toolbox/actions/git/get-highest-semver-tag@main
     with:
       path: ${{ inputs.path }}
 


### PR DESCRIPTION
- **refactor: call git/get-highest-semver-tag instead of git/get-latest-version-tag from dotnet/bump-version-tag macro**
- **refactor: rename id latest-tag -> highest-tag in dotnet/bump-version-tag macro**
